### PR TITLE
rectangle-color-flickering

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,8 @@
 		<script src="https://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
 
 		<!--Leaflet AND Leaflet.PM for editing -->
-		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
-		integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
-		crossorigin=""/>
-		<script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
-		integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
-		crossorigin=""></script>
+		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin="" />
+		<script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js" integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew==" crossorigin=""></script>
 		<link rel="stylesheet" href="https://unpkg.com/leaflet.pm@2.1.0/dist/leaflet.pm.css" />
 		<!-- <script src="https://unpkg.com/leaflet.pm@2.1.0/dist/leaflet.pm.min.js"></script> -->
 		<!-- until https://github.com/codeofsumit/leaflet.pm/pull/464 is merged -->
@@ -244,7 +240,6 @@
 			<div id="output">
 				<div id="printout"></div>
 				<div id="result" class="results"></div>
-				<div id="previewMap"></div>
 				<div id="previewMap">
 					<canvas></canvas>
 					<div id="projectionName"></div>

--- a/map.js
+++ b/map.js
@@ -255,6 +255,7 @@ function addRectangle (map) {
 
 		// TODO: decide if you want to always force ON the orange color when starting a vertex drag
 		// i.e. orange: rectangle.fire('mouseover');
+		rectangle.fire('mouseover');
 
 		// while dragging any of the corner vertices,
 		// turn OFF the mouseover and mouseout handlers that can conflictingly change the rectangle colors
@@ -270,6 +271,7 @@ function addRectangle (map) {
 		// TODO: decide if you want to always force ON the orange or blue color after a vertex drag end
 		// i.e. orange: rectangle.fire('mouseover');
 		// i.e. blue: rectangle.fire('mouseout');
+		rectangle.fire('mouseout');
 	});
 
 	rectangle.on("pm:drag", function(e) {

--- a/map.js
+++ b/map.js
@@ -276,7 +276,7 @@ function addRectangle (map) {
 	rectangle.on("pm:drag", function(e) {
 		const rectangle = e.sourceTarget;
 		// reading changed bounds
-		var newBounds = map.options.crs.wrapLatLngBounds(rectangle.getBounds());
+		var newBounds = rectangle.getBounds();
 
 		var SW = newBounds.getSouthWest();
 		var NE = newBounds.getNorthEast();

--- a/map.js
+++ b/map.js
@@ -357,7 +357,7 @@ function addRectangle (map) {
 				color : "#3388ff" // blue
 			});
 
-			// re-enable the map's default behavior of doubleClickZoom after "map.fitBounds(recBounds);" occurs
+			// re-enable the map's default behavior of doubleClickZoom
 			map.doubleClickZoom.enable();
 		});
 	}

--- a/map.js
+++ b/map.js
@@ -260,14 +260,14 @@ function addRectangle (map) {
 
 		// while dragging any of the corner vertices,
 		// turn OFF the mouseover and mouseout handlers that can conflictingly change the rectangle colors
-		pauseRectangleStyleEvents();
+		pauseRectangleInteractionEvents();
 	});
 
 	rectangle.on("pm:markerdragend", function () {
 		toggleAnchorVisibility();
 
 		// turn ON the mouseover and mouseout handlers that change the rectangle colors
-		resumeRectangleStyleEvents();
+		resumeRectangleInteractionEvents();
 
 		// force OFF the orange color after a vertex drag end to return to the non-editing blue color
 		rectangle.fire('mouseout');
@@ -302,8 +302,6 @@ function addRectangle (map) {
 			}
 		}
 
-		// TODO: sometimes "oppositeCorner" is undefined;
-		// this issue can appear as a console error when "flipping" the rectangle by dragging a vertex around
 		const deltaLng = Math.abs(liveCorner.lng - oppositeCorner.lng);
 
 		// dont allow the horizontal span of the rectangle to exceed 360deg
@@ -335,18 +333,21 @@ function addRectangle (map) {
 		map.fitBounds(recBounds);
 	});
 
-	function pauseRectangleStyleEvents() {
+	function pauseRectangleInteractionEvents() {
 		rectangle.off('mouseover');
 		rectangle.off('mouseout');
 	}
 
-	function resumeRectangleStyleEvents() {
+	function resumeRectangleInteractionEvents() {
 		//Event handler: Mouse over the rectangle
 		rectangle.on("mouseover", function(e) {
 			//Setting active editing style
 			rectangle.setStyle({
 				color: "#ff7b1a" // orange
 			});
+
+			// temporarily disable the map's default behavior of doubleClickZoom
+			map.doubleClickZoom.disable();
 		});
 	
 		//Event handler: Mouse out the rectangle
@@ -355,6 +356,9 @@ function addRectangle (map) {
 			rectangle.setStyle({
 				color : "#3388ff" // blue
 			});
+
+			// re-enable the map's default behavior of doubleClickZoom after "map.fitBounds(recBounds);" occurs
+			map.doubleClickZoom.enable();
 		});
 	}
 
@@ -363,14 +367,14 @@ function addRectangle (map) {
 
 		// while dragging the entire rectangle,
 		// turn OFF the mouseover and mouseout handlers that can conflictingly change the rectangle colors
-		pauseRectangleStyleEvents();
+		pauseRectangleInteractionEvents();
 	});
 
 	rectangle.on('pm:dragend', function (e) {
 		toggleAnchorVisibility();
 
 		// turn ON the mouseover and mouseout handlers that change the rectangle colors
-		resumeRectangleStyleEvents()
+		resumeRectangleInteractionEvents()
 
 		// while the user is still hovering over the rectangle after dragging is finished,
 		// try to prevent the pm editor code from reverting back to the starting blue color
@@ -396,7 +400,7 @@ function addRectangle (map) {
 	map.pm.toggleGlobalDragMode();
 
 	// turn ON the mouseover and mouseout handlers that change the rectangle colors
-	resumeRectangleStyleEvents();
+	resumeRectangleInteractionEvents();
 }
 
 /*MAIN FUNCTION*/
@@ -472,7 +476,6 @@ function init() {
 	//Creates a map
 	map = new L.Map('map', {
 		attributionControl: false,
-		doubleClickZoom: false
 	}).setView([0,0], 0);
 
 	//Fit bounds button

--- a/map.js
+++ b/map.js
@@ -135,39 +135,7 @@ function changeInput () {
 	updateMapArea(North, South, East, West);
 	updateRectangle();
 
-	// fit the map's view if the rectangle is not fully contained by the current map bounds
-
-	// NOTE 1: but first ensure that the rectangle's north and south are within the map's CRS MAX_LATITUDE,
-	// otherwise the "map.getBounds().contains()"" method will not always provide correct answers
-
-	// NOTE 2: if you want to simply ALWAYS do "map.fitBounds(rectangle.getBounds());",
-	// then you don't need to fix the north and south bounds
-	// (again, this is only needed for the "map.getBounds().contains()" method)
-	var rectangleBounds = rectangle.getBounds();
-	var validRectangleBounds = [
-		[
-			// southwest corner
-			// manually update the southern value (e.g. if south is -90, it should actually be -85.0511287798)
-			rectangleBounds.getSouth() >= -map.options.crs.projection.MAX_LATITUDE
-				? rectangleBounds.getSouth()
-				: -map.options.crs.projection.MAX_LATITUDE,
-			rectangleBounds.getWest()
-		],
-		[
-			// northeast corner
-			// manually update the northern value (e.g. if north is +90, it should actually be 85.0511287798)
-			rectangleBounds.getNorth() <= map.options.crs.projection.MAX_LATITUDE
-				? rectangleBounds.getNorth()
-				: map.options.crs.projection.MAX_LATITUDE,
-			rectangleBounds.getEast()
-		]
-	];
-
-	validRectangleBounds = L.latLngBounds(validRectangleBounds);
-
-	if (!map.getBounds().contains(validRectangleBounds)) {
-		map.fitBounds(rectangle.getBounds());
-	}
+	map.fitBounds(rectangle.getBounds());
 }
 
 /*RESET BUTTON CALLBACK FUNCTION*/
@@ -271,11 +239,7 @@ function addRectangle (map) {
 	rectangle.on('pm:edit', function (e) {
 		const rectangle = e.sourceTarget;
 		// reading changed bounds
-		
-		// TODO: new code suggestion:
-		// decide if you want to wrap the bounds to try to contain the East and West numbers from getting too large when dragging the rectangle very far east or west
-		// var newBounds = rectangle.getBounds();
-		var newBounds = map.options.crs.wrapLatLngBounds(rectangle.getBounds());
+		var newBounds = rectangle.getBounds();
 
 		var SW = newBounds.getSouthWest();
 		var NE = newBounds.getNorthEast();
@@ -312,10 +276,6 @@ function addRectangle (map) {
 	rectangle.on("pm:drag", function(e) {
 		const rectangle = e.sourceTarget;
 		// reading changed bounds
-		
-		// TODO: new code suggestion:
-		// decide if you want to wrap the bounds to try to contain the East and West numbers from getting too large when dragging the rectangle very far east or west
-		// var newBounds = rectangle.getBounds();
 		var newBounds = map.options.crs.wrapLatLngBounds(rectangle.getBounds());
 
 		var SW = newBounds.getSouthWest();

--- a/outputFormat.js
+++ b/outputFormat.js
@@ -149,13 +149,13 @@ function printWorld(property, center, currentlyDragging) {
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as points</b></p>");
 		//loop through global data
 		for (var i = 0; i < 2; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as lines</b></p>");
 		//loop through global data
 		for (var i = 2; i < 6; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);
@@ -181,12 +181,12 @@ function printWorld(property, center, currentlyDragging) {
 		addWorldMapPreview(center, "Natural Earth", currentlyDragging);
 		//loop through global data
 		for (var i = 6; i < 9; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		outputTEXT.append("<p><b>Compromise rectangular world map projections</b></p>");
 		//loop through global data
 		for (var i = 9; i < 12; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);

--- a/outputFormat.js
+++ b/outputFormat.js
@@ -149,13 +149,13 @@ function printWorld(property, center, currentlyDragging) {
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as points</b></p>");
 		//loop through global data
 		for (var i = 0; i < 2; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as lines</b></p>");
 		//loop through global data
 		for (var i = 2; i < 6; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);
@@ -181,12 +181,12 @@ function printWorld(property, center, currentlyDragging) {
 		addWorldMapPreview(center, "Natural Earth", currentlyDragging);
 		//loop through global data
 		for (var i = 6; i < 9; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		outputTEXT.append("<p><b>Compromise rectangular world map projections</b></p>");
 		//loop through global data
 		for (var i = 9; i < 12; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);

--- a/outputFormat.js
+++ b/outputFormat.js
@@ -149,13 +149,13 @@ function printWorld(property, center, currentlyDragging) {
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as points</b></p>");
 		//loop through global data
 		for (var i = 0; i < 2; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as lines</b></p>");
 		//loop through global data
 		for (var i = 2; i < 6; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);
@@ -181,12 +181,12 @@ function printWorld(property, center, currentlyDragging) {
 		addWorldMapPreview(center, "Natural Earth", currentlyDragging);
 		//loop through global data
 		for (var i = 6; i < 9; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		outputTEXT.append("<p><b>Compromise rectangular world map projections</b></p>");
 		//loop through global data
 		for (var i = 9; i < 12; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);

--- a/outputFormat.js
+++ b/outputFormat.js
@@ -149,13 +149,13 @@ function printWorld(property, center, currentlyDragging) {
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as points</b></p>");
 		//loop through global data
 		for (var i = 0; i < 2; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 
 		outputTEXT.append("<p><b>Equal-area world map projections with poles represented as lines</b></p>");
 		//loop through global data
 		for (var i = 2; i < 6; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);
@@ -181,12 +181,12 @@ function printWorld(property, center, currentlyDragging) {
 		addWorldMapPreview(center, "Natural Earth", currentlyDragging);
 		//loop through global data
 		for (var i = 6; i < 9; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		outputTEXT.append("<p><b>Compromise rectangular world map projections</b></p>");
 		//loop through global data
 		for (var i = 9; i < 12; i++) {
-			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span style='text-decoration: dashed underline;'>" + listWorld[i].projection + "</span>" + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
+			outputTEXT.append("<p class='outputText'><span onmouseover='updateWorldMap(\"" + listWorld[i].projection + "\")'><span>" + listWorld[i].projection + stringLinks(listWorld[i].PROJ4, NaN, NaN, NaN, NaN, lng, NaN) + "<\span></p>");
 		}
 		
 		worldCM(lng, outputTEXT);


### PR DESCRIPTION
changes includes:

- updates to orange/blue rectangle color flickering
- double click zoom is re-enabled for the map overall, but if the user double clicks on the rectangle then the map's bounds are fit to the rectangle
- when the user makes a coordinate input field change, the map's bounds are always set to the new rectangle
- upgraded to Leaflet v1.6.0